### PR TITLE
Harden error handling and clean imports in core modules

### DIFF
--- a/src/camillafir/camillafir.py
+++ b/src/camillafir/camillafir.py
@@ -10,28 +10,21 @@ if __package__ in (None, ""):
     __package__ = "camillafir"
 
 import io
-import json
 import logging
-import re
 import zipfile
 import typing
 import scipy.io.wavfile
 import math
 from datetime import datetime
-from textwrap import dedent
-import math
 import numpy as np
-from pywebio import config, start_server
+from pywebio import start_server
 from pywebio.input import *
 from pywebio.output import *
 from pywebio.pin import *
-from pywebio.session import set_env
-import pywebio.output as pwo
 #from pywebio.output import toast
-from pywebio.output import put_html
-from .config.camillafir_config import load_config, save_config
+from .config.camillafir_config import save_config
 from .resources.i8n.camillafir_i18n import t
-from .ui.camillafir_housecurve import _normalize_hc_mode_key, get_house_curve_by_name, load_target_curve, load_house_curve
+from .ui.camillafir_housecurve import load_house_curve
 from camillafir.io.measurements_loader import load_measurements_lr
 from camillafir.io.measurements_txt import parse_measurements_from_path
 from .ui.camillafir_ui_helpers import (

--- a/src/camillafir/config/camillafir_pipeline.py
+++ b/src/camillafir/config/camillafir_pipeline.py
@@ -38,7 +38,7 @@ def collect_ui_data(pin) -> Dict[str, Any]:
     for k in p_keys:
         try:
             data[k] = pin[k]
-        except Exception:
+        except KeyError:
             data[k] = None
 
     # normalize checkbox pins saved as [] / [True]
@@ -58,17 +58,17 @@ def collect_ui_data(pin) -> Dict[str, Any]:
     for i in range(1, 6):
         try:
             data[f"xo{i}_f"] = pin[f"xo{i}_f"]
-        except Exception:
+        except KeyError:
             data[f"xo{i}_f"] = None
         try:
             data[f"xo{i}_s"] = pin[f"xo{i}_s"]
-        except Exception:
+        except KeyError:
             data[f"xo{i}_s"] = None
 
     # numeric clamps (same behavior as camillafir.py)
     try:
         data["max_cut_db"] = abs(float(data.get("max_cut_db", 15.0) or 15.0))
-    except Exception:
+    except (TypeError, ValueError):
         data["max_cut_db"] = 15.0
 
     for k, dv in [
@@ -79,7 +79,7 @@ def collect_ui_data(pin) -> Dict[str, Any]:
     ]:
         try:
             data[k] = max(0.0, float(data.get(k, dv) or dv))
-        except Exception:
+        except (TypeError, ValueError):
             data[k] = dv
 
     v_raw = data.get("ir_export_window_mode", None)

--- a/src/camillafir/io/measurements_wav.py
+++ b/src/camillafir/io/measurements_wav.py
@@ -5,7 +5,7 @@ import scipy.io.wavfile
 
 try:
     # Preferred: dedicated helper (closer to REW .txt export)
-    from src.camillafir.io.camillafir_wav_window import ir_wav_to_freq_response as _wav_ir_to_fr
+    from .camillafir_wav_window import ir_wav_to_freq_response as _wav_ir_to_fr
 except Exception:
     _wav_ir_to_fr = None
 

--- a/src/camillafir/ui/camillafir_ui_helpers.py
+++ b/src/camillafir/ui/camillafir_ui_helpers.py
@@ -1,4 +1,5 @@
 # camillafir_ui_helpers.py
+import logging
 import numpy as np
 import math
 from pywebio.output import *  # needed because this PyWebIO build doesn't expose put_input/put_select as named exports
@@ -8,6 +9,8 @@ from pywebio.pin import pin, pin_update, put_input, put_select
 from ..resources.i8n.camillafir_i18n import t
 from .camillafir_modes import MODE_DEFAULTS
 from .camillafir_utils import scale_taps_with_fs
+
+logger = logging.getLogger("CamillaFIR")
 
 def _warn_max_boost_if_over_cap(_=None):
     """


### PR DESCRIPTION
### Motivation
- Reduce fragile imports and undefined-name risks in UI and I/O modules to improve runtime robustness and maintainability.
- Replace overly-broad exception handlers with targeted exceptions to avoid silently swallowing bugs in UI data collection.
- Use package-relative imports to avoid brittle absolute module paths when running as a package or script.
- Clean obvious unused and duplicate imports to make the main entry module clearer.

### Description
- Added a module `logger` in `src/camillafir/ui/camillafir_ui_helpers.py` to avoid references to an undefined logging name in exception paths.
- Replaced the fragile absolute import in `src/camillafir/io/measurements_wav.py` with a relative import: `from .camillafir_wav_window import ...`.
- Tightened `collect_ui_data()` in `src/camillafir/config/camillafir_pipeline.py` by changing `except Exception` to `except KeyError` for missing pins and `except (TypeError, ValueError)` for numeric conversion fallbacks.
- Removed duplicate and clearly unused imports from `src/camillafir/camillafir.py` (including a duplicate `math` import) to simplify the entry module.

### Testing
- Ran `python -m compileall -q src` which completed successfully, confirming modules compile.
- Ran `ruff check` on the modified files which reported existing lint findings (94 errors found, 15 fixable) but the changes are scoped and do not introduce new syntax errors.
- Ran `pytest -q` which discovered no tests in the repository (no tests ran).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699094578e7083268f0553184404112a)